### PR TITLE
Support big intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # go-datastructures
+
+### augmentedtree
+
+This is an implemnetation of an interval tree for collision in n-dimensional ranges. It is a fork of [augmentedtree package](https://github.com/Workiva/go-datastructures) from Workiva with one modification: it supports intervals with integers of arbitrary size using Go's [math/big](https://golang.org/pkg/math/big/) package.

--- a/augmentedtree/atree.go
+++ b/augmentedtree/atree.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 Workiva, LLC
+Copyright 2018 Packet Clearing House
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/augmentedtree/atree_test.go
+++ b/augmentedtree/atree_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 Workiva, LLC
+Copyright 2018 Packet Clearing House
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/augmentedtree/interface.go
+++ b/augmentedtree/interface.go
@@ -31,6 +31,10 @@ range handling.
 */
 package augmentedtree
 
+import (
+	"math/big"
+)
+
 // Interval is the interface that must be implemented by any
 // item added to the interval tree.  This interface is similar to the
 // interval found in the rangetree package and it should be possible
@@ -41,10 +45,10 @@ package augmentedtree
 type Interval interface {
 	// LowAtDimension returns an integer representing the lower bound
 	// at the requested dimension.
-	LowAtDimension(uint64) int64
+	LowAtDimension(uint64) big.Int
 	// HighAtDimension returns an integer representing the higher bound
 	// at the requested dimension.
-	HighAtDimension(uint64) int64
+	HighAtDimension(uint64) big.Int
 	// OverlapsAtDimension should return a bool indicating if the provided
 	// interval overlaps this interval at the dimension requested.
 	OverlapsAtDimension(Interval, uint64) bool

--- a/augmentedtree/interface.go
+++ b/augmentedtree/interface.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 Workiva, LLC
+Copyright 2018 Packet Clearing House
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/augmentedtree/intervals.go
+++ b/augmentedtree/intervals.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 Workiva, LLC
+Copyright 2018 Packet Clearing House
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/augmentedtree/intervals_test.go
+++ b/augmentedtree/intervals_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 Workiva, LLC
+Copyright 2018 Packet Clearing House
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/augmentedtree/mock_test.go
+++ b/augmentedtree/mock_test.go
@@ -16,10 +16,13 @@ limitations under the License.
 
 package augmentedtree
 
-import "fmt"
+import (
+	"fmt"
+	"math/big"
+)
 
 type dimension struct {
-	low, high int64
+	low, high big.Int
 }
 
 type mockInterval struct {
@@ -33,17 +36,20 @@ func (mi *mockInterval) checkDimension(dimension uint64) {
 	}
 }
 
-func (mi *mockInterval) LowAtDimension(dimension uint64) int64 {
+func (mi *mockInterval) LowAtDimension(dimension uint64) big.Int {
 	return mi.dimensions[dimension-1].low
 }
 
-func (mi *mockInterval) HighAtDimension(dimension uint64) int64 {
+func (mi *mockInterval) HighAtDimension(dimension uint64) big.Int {
 	return mi.dimensions[dimension-1].high
 }
 
 func (mi *mockInterval) OverlapsAtDimension(iv Interval, dimension uint64) bool {
-	return mi.HighAtDimension(dimension) > iv.LowAtDimension(dimension) &&
-		mi.LowAtDimension(dimension) < iv.HighAtDimension(dimension)
+	miHigh := mi.HighAtDimension(dimension)
+	miLow := mi.LowAtDimension(dimension)
+	ivHigh := iv.HighAtDimension(dimension)
+	ivLow := iv.LowAtDimension(dimension)
+	return miHigh.Cmp(&ivLow) > 0 && miLow.Cmp(&ivHigh) < 0
 }
 
 func (mi mockInterval) ID() uint64 {
@@ -51,9 +57,13 @@ func (mi mockInterval) ID() uint64 {
 }
 
 func constructSingleDimensionInterval(low, high int64, id uint64) *mockInterval {
-	return &mockInterval{[]*dimension{&dimension{low: low, high: high}}, id}
+	return &mockInterval{[]*dimension{&dimension{low: *big.NewInt(low), high: *big.NewInt(high)}}, id}
 }
 
 func constructMultiDimensionInterval(id uint64, dimensions ...*dimension) *mockInterval {
 	return &mockInterval{dimensions: dimensions, id: id}
+}
+
+func constructDimension(low, high int64) *dimension {
+	return &dimension{low: *big.NewInt(low), high: *big.NewInt(high)}
 }

--- a/augmentedtree/mock_test.go
+++ b/augmentedtree/mock_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 Workiva, LLC
+Copyright 2018 Packet Clearing House
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/augmentedtree/multidimensional_test.go
+++ b/augmentedtree/multidimensional_test.go
@@ -28,17 +28,17 @@ func constructMultiDimensionQueryTestTree() (
 	it := newTree(2)
 
 	iv1 := constructMultiDimensionInterval(
-		0, &dimension{low: 5, high: 10}, &dimension{low: 5, high: 10},
+		0, constructDimension(5, 10), constructDimension(5, 10),
 	)
 	it.Add(iv1)
 
 	iv2 := constructMultiDimensionInterval(
-		1, &dimension{low: 4, high: 5}, &dimension{low: 4, high: 5},
+		1, constructDimension(4, 5), constructDimension(4, 5),
 	)
 	it.Add(iv2)
 
 	iv3 := constructMultiDimensionInterval(
-		2, &dimension{low: 7, high: 12}, &dimension{low: 7, high: 12},
+		2, constructDimension(7, 12), constructDimension(7, 12),
 	)
 	it.Add(iv3)
 
@@ -48,7 +48,7 @@ func constructMultiDimensionQueryTestTree() (
 func TestRootAddMultipleDimensions(t *testing.T) {
 	it := newTree(2)
 	iv := constructMultiDimensionInterval(
-		1, &dimension{low: 0, high: 5}, &dimension{low: 1, high: 6},
+		1, constructDimension(0, 5), constructDimension(1, 6),
 	)
 
 	it.Add(iv)
@@ -56,14 +56,14 @@ func TestRootAddMultipleDimensions(t *testing.T) {
 	checkRedBlack(t, it.root, 1)
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 10}, &dimension{0, 10},
+			0, constructDimension(0, 10), constructDimension(0, 10),
 		),
 	)
 	assert.Equal(t, Intervals{iv}, result)
 
 	result = it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{100, 200}, &dimension{100, 200},
+			0, constructDimension(100, 200), constructDimension(100, 200),
 		),
 	)
 	assert.Len(t, result, 0)
@@ -76,35 +76,35 @@ func TestMultipleAddMultipleDimensions(t *testing.T) {
 
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 100}, &dimension{0, 100},
+			0, constructDimension(0, 100), constructDimension(0, 100),
 		),
 	)
 	assert.Equal(t, Intervals{iv2, iv1, iv3}, result)
 
 	result = it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{3, 5}, &dimension{3, 5},
+			0, constructDimension(3, 5), constructDimension(3, 5),
 		),
 	)
 	assert.Equal(t, Intervals{iv2}, result)
 
 	result = it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{5, 8}, &dimension{5, 8},
+			0, constructDimension(5, 8), constructDimension(5, 8),
 		),
 	)
 	assert.Equal(t, Intervals{iv1, iv3}, result)
 
 	result = it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{11, 15}, &dimension{11, 15},
+			0, constructDimension(11, 15), constructDimension(11, 15),
 		),
 	)
 	assert.Equal(t, Intervals{iv3}, result)
 
 	result = it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{15, 20}, &dimension{15, 20},
+			0, constructDimension(15, 20), constructDimension(15, 20),
 		),
 	)
 	assert.Len(t, result, 0)
@@ -115,7 +115,7 @@ func TestAddRebalanceInOrderMultiDimensions(t *testing.T) {
 
 	for i := int64(0); i < 10; i++ {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{i, i + 1}, &dimension{i, i + 1},
+			uint64(i), constructDimension(i, i+1), constructDimension(i, i+1),
 		)
 		it.Add(iv)
 	}
@@ -123,7 +123,7 @@ func TestAddRebalanceInOrderMultiDimensions(t *testing.T) {
 	checkRedBlack(t, it.root, 1)
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 10}, &dimension{0, 10},
+			0, constructDimension(0, 10), constructDimension(0, 10),
 		),
 	)
 	assert.Len(t, result, 10)
@@ -135,7 +135,7 @@ func TestAddRebalanceReverseOrderMultiDimensions(t *testing.T) {
 
 	for i := int64(9); i >= 0; i-- {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{i, i + 1}, &dimension{i, i + 1},
+			uint64(i), constructDimension(i, i+1), constructDimension(i, i+1),
 		)
 		it.Add(iv)
 	}
@@ -143,7 +143,7 @@ func TestAddRebalanceReverseOrderMultiDimensions(t *testing.T) {
 	checkRedBlack(t, it.root, 1)
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 10}, &dimension{0, 10},
+			0, constructDimension(0, 10), constructDimension(0, 10),
 		),
 	)
 	assert.Len(t, result, 10)
@@ -157,7 +157,7 @@ func TestAddRebalanceRandomOrderMultiDimensions(t *testing.T) {
 
 	for i, start := range starts {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{start, start + 1}, &dimension{start, start + 1},
+			uint64(i), constructDimension(start, start+1), constructDimension(start, start+1),
 		)
 		it.Add(iv)
 	}
@@ -165,7 +165,7 @@ func TestAddRebalanceRandomOrderMultiDimensions(t *testing.T) {
 	checkRedBlack(t, it.root, 1)
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 10}, &dimension{0, 10},
+			0, constructDimension(0, 10), constructDimension(0, 10),
 		),
 	)
 	assert.Len(t, result, 5)
@@ -178,7 +178,7 @@ func TestAddLargeNumbersMultiDimensions(t *testing.T) {
 
 	for i := int64(0); i < numItems; i++ {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{i, i + 1}, &dimension{i, i + 1},
+			uint64(i), constructDimension(i, i+1), constructDimension(i, i+1),
 		)
 		it.Add(iv)
 	}
@@ -186,7 +186,7 @@ func TestAddLargeNumbersMultiDimensions(t *testing.T) {
 	checkRedBlack(t, it.root, 1)
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, numItems}, &dimension{0, numItems},
+			0, constructDimension(0, numItems), constructDimension(0, numItems),
 		),
 	)
 	assert.Len(t, result, int(numItems))
@@ -199,7 +199,7 @@ func BenchmarkAddItemsMultiDimensions(b *testing.B) {
 
 	for i := int64(0); i < numItems; i++ {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{i, i + 1}, &dimension{i, i + 1},
+			uint64(i), constructDimension(i, i+1), constructDimension(i, i+1),
 		)
 		intervals = append(intervals, iv)
 	}
@@ -218,7 +218,7 @@ func BenchmarkQueryItemsMultiDimensions(b *testing.B) {
 
 	for i := int64(0); i < numItems; i++ {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{i, i + 1}, &dimension{i, i + 1},
+			uint64(i), constructDimension(i, i+1), constructDimension(i, i+1),
 		)
 		intervals = append(intervals, iv)
 	}
@@ -230,7 +230,7 @@ func BenchmarkQueryItemsMultiDimensions(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		it.Query(
 			constructMultiDimensionInterval(
-				0, &dimension{0, numItems}, &dimension{0, numItems},
+				0, constructDimension(0, numItems), constructDimension(0, numItems),
 			),
 		)
 	}
@@ -239,7 +239,7 @@ func BenchmarkQueryItemsMultiDimensions(b *testing.B) {
 func TestRootDeleteMultiDimensions(t *testing.T) {
 	it := newTree(2)
 	iv := constructMultiDimensionInterval(
-		0, &dimension{low: 5, high: 10}, &dimension{low: 5, high: 10},
+		0, constructDimension(5, 10), constructDimension(5, 10),
 	)
 	it.Add(iv)
 
@@ -248,7 +248,7 @@ func TestRootDeleteMultiDimensions(t *testing.T) {
 	checkRedBlack(t, it.root, 1)
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 100}, &dimension{0, 100},
+			0, constructDimension(0, 100), constructDimension(0, 100),
 		),
 	)
 	assert.Len(t, result, 0)
@@ -264,35 +264,35 @@ func TestDeleteMultiDimensions(t *testing.T) {
 
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 100}, &dimension{0, 100},
+			0, constructDimension(0, 100), constructDimension(0, 100),
 		),
 	)
 	assert.Equal(t, Intervals{iv2, iv3}, result)
 
 	result = it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{3, 5}, &dimension{3, 5},
+			0, constructDimension(3, 5), constructDimension(3, 5),
 		),
 	)
 	assert.Equal(t, Intervals{iv2}, result)
 
 	result = it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{5, 8}, &dimension{5, 8},
+			0, constructDimension(5, 8), constructDimension(5, 8),
 		),
 	)
 	assert.Equal(t, Intervals{iv3}, result)
 
 	result = it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{11, 15}, &dimension{11, 15},
+			0, constructDimension(11, 15), constructDimension(11, 15),
 		),
 	)
 	assert.Equal(t, Intervals{iv3}, result)
 
 	result = it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{15, 20}, &dimension{15, 20},
+			0, constructDimension(15, 20), constructDimension(15, 20),
 		),
 	)
 	assert.Len(t, result, 0)
@@ -305,7 +305,7 @@ func TestDeleteRebalanceInOrderMultiDimensions(t *testing.T) {
 
 	for i := int64(0); i < 10; i++ {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{i, i + 1}, &dimension{i, i + 1},
+			uint64(i), constructDimension(i, i+1), constructDimension(i, i+1),
 		)
 		it.Add(iv)
 		if i == 5 {
@@ -318,7 +318,7 @@ func TestDeleteRebalanceInOrderMultiDimensions(t *testing.T) {
 	checkRedBlack(t, it.root, 1)
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 10}, &dimension{0, 10},
+			0, constructDimension(0, 10), constructDimension(0, 10),
 		),
 	)
 	assert.Len(t, result, 9)
@@ -332,7 +332,7 @@ func TestDeleteRebalanceReverseOrderMultiDimensions(t *testing.T) {
 
 	for i := int64(9); i >= 0; i-- {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{i, i + 1}, &dimension{i, i + 1},
+			uint64(i), constructDimension(i, i+1), constructDimension(i, i+1),
 		)
 		it.Add(iv)
 		if i == 5 {
@@ -345,7 +345,7 @@ func TestDeleteRebalanceReverseOrderMultiDimensions(t *testing.T) {
 	checkRedBlack(t, it.root, 1)
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 10}, &dimension{0, 10},
+			0, constructDimension(0, 10), constructDimension(0, 10),
 		),
 	)
 	assert.Len(t, result, 9)
@@ -361,7 +361,7 @@ func TestDeleteRebalanceRandomOrderMultiDimensions(t *testing.T) {
 
 	for i, start := range starts {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{start, start + 1}, &dimension{start, start + 1},
+			uint64(i), constructDimension(start, start+1), constructDimension(start, start+1),
 		)
 		it.Add(iv)
 		if start == 1 {
@@ -374,7 +374,7 @@ func TestDeleteRebalanceRandomOrderMultiDimensions(t *testing.T) {
 	checkRedBlack(t, it.root, 1)
 	result := it.Query(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 10}, &dimension{0, 10},
+			0, constructDimension(0, 10), constructDimension(0, 10),
 		),
 	)
 	assert.Len(t, result, 4)
@@ -386,7 +386,7 @@ func TestDeleteEmptyTreeMultiDimensions(t *testing.T) {
 
 	it.Delete(
 		constructMultiDimensionInterval(
-			0, &dimension{0, 10}, &dimension{0, 10},
+			0, constructDimension(0, 10), constructDimension(0, 10),
 		),
 	)
 	assert.Equal(t, uint64(0), it.Len())
@@ -398,7 +398,7 @@ func BenchmarkDeleteItemsMultiDimensions(b *testing.B) {
 
 	for i := int64(0); i < numItems; i++ {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{i, i + 1}, &dimension{i, i + 1},
+			uint64(i), constructDimension(i, i+1), constructDimension(i, i+1),
 		)
 		intervals = append(intervals, iv)
 	}
@@ -424,7 +424,7 @@ func TestAddDeleteDuplicatesRebalanceInOrderMultiDimensions(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{0, 10}, &dimension{0, 10},
+			uint64(i), constructDimension(0, 10), constructDimension(0, 10),
 		)
 		intervals = append(intervals, iv)
 	}
@@ -441,7 +441,7 @@ func TestAddDeleteDuplicatesRebalanceReverseOrderMultiDimensions(t *testing.T) {
 
 	for i := 9; i >= 0; i-- {
 		iv := constructMultiDimensionInterval(
-			uint64(i), &dimension{0, 10}, &dimension{0, 10},
+			uint64(i), constructDimension(0, 10), constructDimension(0, 10),
 		)
 		intervals = append(intervals, iv)
 	}
@@ -459,7 +459,7 @@ func TestAddDeleteDuplicatesRebalanceRandomOrderMultiDimensions(t *testing.T) {
 
 	for _, start := range starts {
 		iv := constructMultiDimensionInterval(
-			uint64(start), &dimension{0, 10}, &dimension{0, 10},
+			uint64(start), constructDimension(0, 10), constructDimension(0, 10),
 		)
 		intervals = append(intervals, iv)
 	}

--- a/augmentedtree/multidimensional_test.go
+++ b/augmentedtree/multidimensional_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 Workiva, LLC
+Copyright 2018 Packet Clearing House
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds support for intervals with integers of arbitrary size using Go's `math/big` package.